### PR TITLE
Refactor path handling in useEffect for improved navigation state man…

### DIFF
--- a/packages/evershop/src/components/admin/cms/NavigationItem.jsx
+++ b/packages/evershop/src/components/admin/cms/NavigationItem.jsx
@@ -4,21 +4,26 @@ import './NavigationItem.scss';
 
 export default function NavigationItem({ Icon, url, title }) {
   const [isActive, setIsActive] = React.useState(false);
-  React.useEffect(() => {
-    const currentUrl = window.location.href;
-    const baseUrl = window.location.origin;
-    const check = currentUrl.split(baseUrl + url);
-    if (check.length === 2 && url.indexOf('products/new') === -1) {
-      // TODO: Fix me
-      if (url.split('/').length === 2) {
-        if (check[1] === '' || !/^\/[a-zA-Z1-9]/.test(check[1])) {
-          setIsActive(true);
-        }
-      } else {
-        setIsActive(true);
-      }
+ 
+ React.useEffect(() => {
+  // TODO: Fix me
+  const currentPath = window.location.pathname;
+  const specialPath = ['/admin/products/new', '/admin/coupon/new', '/admin'];
+
+  // Check if the current path is one of the special paths
+  if (specialPath.includes(currentPath)) {
+    // If the current path matches the URL, set the active state to true
+    if (currentPath === url) {
+      setIsActive(true);
     }
-  }, []);
+    return;
+  }
+
+  // Check if the current path starts with the URL and is not the dashboard
+  if (currentPath.startsWith(url) && url !== '/admin') {
+    setIsActive(true);
+  }
+}, []);
 
   return (
     <li className={isActive ? 'active nav-item' : 'nav-item'}>


### PR DESCRIPTION
…agement in NavigationItem.jsx

## Refactor path handling in useEffect for improved navigation state management

- Replaced complex URL parsing logic with simpler pathname checks.
- Converted from checking `window.location.href` and `window.location.origin` to using `window.location.pathname` for cleaner path management.
- Added handling for special paths like '/admin/products/new', '/admin/coupon/new', and '/admin' to set active state based on exact path matches.
- Enhanced logic to ensure correct navigation item activation based on current path, handling cases where new items should be activated rather than general categories.

Changes:
- Simplified path comparison and activation logic.
- Addressed specific cases for 'new' items to ensure correct active state management.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When I click 'New Product', the navigation item does not become active (The 'Product' item is active instead of 'New Product'.). However, when I click 'New Coupon', the navigation item becomes active as expected.


#### product
![Screenshot_20240912_220908](https://github.com/user-attachments/assets/8adc733f-33e6-4bcf-bddc-1a3db3229a0d)

#### coupon
![Screenshot_20240912_221411](https://github.com/user-attachments/assets/a6caa071-75dd-4898-90de-65e2975267e1)

Issue Number: N/A


## What is the new behavior?
I fixed the issue, and now 'Product' behaves the same way as 'New Coupon'—the navigation item becomes active as expected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
