### PR TITLE
Added e2e test cases using testRigor

### DIFF
--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -29,9 +29,54 @@ jobs:
       - name: Verify EverShop storefront is up
         run: curl -LI http://143.198.70.2:4000
 
-      - name: Run testRigor suite against EverShop
+      - name: Run testRigor suite via API
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: testrigor --cicdToken "${TESTRIGOR_CICD_TOKEN}" --suiteId "${TESTRIGOR_SUITE_ID}" --url "http://143.198.70.2:4000"
+        run: |
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            -H "auth-token: ${TESTRIGOR_CICD_TOKEN}" \
+            --data '{"forceCancelPreviousTesting":true,"storedValues":{"storedValueName1":"Value"}}' \
+            "https://api.testrigor.com/api/v1/apps/${TESTRIGOR_SUITE_ID}/retest"
 
+          sleep 10
+
+          while true
+          do
+            echo " "
+            echo "==================================="
+            echo " Checking run status"
+            echo "==================================="
+            response=$(curl -i -s -X GET "https://api.testrigor.com/api/v1/apps/${TESTRIGOR_SUITE_ID}/status" -H "auth-token: ${TESTRIGOR_CICD_TOKEN}" -H "Accept: application/json")
+            code=$(echo "$response" | grep HTTP | awk '{print $2}')
+            body=$(echo "$response" | sed -n '/{/,/}/p')
+            echo "Status code: $code"
+            echo "Response: $body"
+            case $code in
+              4*|5*)
+                echo "Error calling API"
+                exit 1
+                ;;
+              200)
+                echo "Test finished successfully"
+                exit 0
+                ;;
+              227|228)
+                echo "Test is not finished yet"
+                ;;
+              229)
+                echo "Test canceled"
+                exit 1
+                ;;
+              230)
+                echo "Test finished but failed"
+                exit 1
+                ;;
+              *)
+                echo "Unknown status"
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -99,5 +99,7 @@ jobs:
           testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
             --token "$TESTRIGOR_CICD_TOKEN" \
             --localhost \
+            --test-cases-path packages/evershop/src/Tests/e2e-testcases/testcases/**/*.txt \
+            --rules-path packages/evershop/src/Tests/e2e-testcases/reusable-rules/**/*.txt \
             --url "http://localhost:3000/admin"
 

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -33,5 +33,5 @@ jobs:
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: |
-          testrigor --cicdToken "$TESTRIGOR_CICD_TOKEN" --suiteId "$TESTRIGOR_SUITE_ID" --url "http://143.198.70.2:4000"
+        run: testrigor --cicdToken "${TESTRIGOR_CICD_TOKEN}" --suiteId "${TESTRIGOR_SUITE_ID}" --url "http://143.198.70.2:4000"
+

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -16,3 +16,26 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install testRigor CLI
+        run: |
+          npm install -g testrigor-cli
+          testrigor --version
+
+      - name: Verify EverShop storefront is up
+        run: curl -LI http://143.198.70.2:4000
+
+      - name: Run testRigor suite against EverShop
+        env:
+          TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
+          TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
+        run: |
+          testrigor \
+            --cicdToken "$TESTRIGOR_CICD_TOKEN" \
+            --suiteId "$TESTRIGOR_SUITE_ID" \
+            --url "http://143.198.70.2:4000"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -99,7 +99,5 @@ jobs:
           testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
             --token "$TESTRIGOR_CICD_TOKEN" \
             --localhost \
-            --test-cases-path packages/evershop/src/Tests/e2e-testcases/testcases/**/*.txt \
-            --rules-path packages/evershop/src/Tests/e2e-testcases/reusable-rules/**/*.txt \
             --url "http://localhost:3000/admin"
 

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -98,4 +98,6 @@ jobs:
         run: |
           testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
             --token "$TESTRIGOR_CICD_TOKEN" \
+            --localhost \
             --url "http://localhost:3000/admin"
+

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -43,9 +43,7 @@ jobs:
         run: npm install
 
       - name: Install EverShop CLI
-        run: |
-          npm install -g evershop
-          evershop --version
+        run: npm install -g evershop || true
 
       - name: Wait for database
         run: sleep 20

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -26,7 +26,10 @@ jobs:
           npm install -g testrigor-cli    
           testrigor --version
           
-      - name: Install testRigor CLI
+      - name: Docker Setup Compose
+        uses: docker/setup-compose-action@v1.2.0
+      
+      - name: Install Evershop with Docker
         run: |
           curl -sSL https://raw.githubusercontent.com/evershopcommerce/evershop/main/docker-compose.yml > docker-compose.yml
           docker-compose up -d

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -1,0 +1,18 @@
+name: EverShop + testRigor CI
+
+on:
+  push:
+    branches:
+      - main
+      - "feature/*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  evershop-testrigor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -12,7 +12,6 @@ jobs:
   evershop-testrigor:
     runs-on: ubuntu-latest
 
-    # 1) Start a Postgres database for EverShop
     services:
       postgres:
         image: postgres:16
@@ -23,7 +22,6 @@ jobs:
         ports:
           - 5432:5432
 
-    # 2) Tell EverShop how to connect to that Postgres DB
     env:
       DB_HOST: 127.0.0.1
       DB_PORT: 5432
@@ -33,29 +31,29 @@ jobs:
       DB_SSLMODE: disable
 
     steps:
-      # A) Get your code
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # B) Install Node.js
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "18"
 
-      # C) Install npm dependencies (this installs @evershop/evershop too)
       - name: Install dependencies
         run: npm install
 
-      # D) Give Postgres a few seconds to be ready
+      # 🔥 FIX: Add EverShop CLI installation
+      - name: Install EverShop CLI
+        run: |
+          npm install -g @evershop/cli
+          evershop --version
+
       - name: Wait for database
         run: sleep 20
 
-      # E) Run EverShop install (creates DB tables, basic config, admin setup logic)
       - name: Run EverShop setup
         run: npm run setup
 
-      # F) Create EverShop admin user (this is the one you use in testRigor)
       - name: Create EverShop admin user
         env:
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
@@ -66,33 +64,20 @@ jobs:
             --password "$ADMIN_PASSWORD" \
             --name "Admin"
 
-      # G) Build the app
       - name: Build EverShop
         run: npm run build
 
-      # H) Start the app (storefront + admin) in the background
       - name: Start EverShop
         run: |
           npm run start &
-          # wait a bit for the server to start
           sleep 25
 
-      # I) Check that the storefront is actually up
       - name: Verify EverShop storefront is up
         run: curl -LI http://localhost:3000
 
-      # J) Install testRigor CLI
       - name: Install testRigor CLI
         run: |
           npm install -g testrigor-cli
           testrigor --version
 
-      # K) Run your testRigor suite against EverShop admin
       - name: Run testRigor suite via CLI
-        env:
-          TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
-          TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: |
-          testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
-            --token "$TESTRIGOR_CICD_TOKEN" \
-            --url "http://localhost:3000/admin"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -23,15 +23,21 @@ jobs:
 
       - name: Install testRigor CLI
         run: |
-          npm install -g testrigor-cli
+          npm install -g testrigor-cli    
           testrigor --version
-
+          
+      - name: Install testRigor CLI
+        run: |
+          curl -sSL https://raw.githubusercontent.com/evershopcommerce/evershop/main/docker-compose.yml > docker-compose.yml
+          docker-compose up -d
+          npm run user:create -- --email ${{ secrets.ADMIN_EMAIL }} --password ${{ secrets.ADMIN_PASS }}  --name "Admin"
+          
       - name: Verify EverShop storefront is up
-        run: curl -LI http://143.198.70.2:4000
+        run: curl -LI http://localhost:3000
 
       - name: Run testRigor suite via CLI
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://143.198.70.2:4000/admin"
+        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://localhost:3000/admin"
 

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -1,4 +1,4 @@
-name: EverShop + testRigor CI (npm)
+name: EverShop + testRigor CI
 
 on:
   push:
@@ -12,71 +12,85 @@ jobs:
   evershop-testrigor:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: evershop
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-
-    env:
-      DB_HOST: 127.0.0.1
-      DB_PORT: 5432
-      DB_USER: postgres
-      DB_PASSWORD: postgres
-      DB_NAME: evershop
-      DB_SSLMODE: disable
-
     steps:
+      # 1) Get your repo (for the workflow + any tests config)
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # 2) Node only for testRigor CLI
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '18'
 
-      - name: Install dependencies
-        run: npm install
+      # 3) Prepare Docker Compose (same as on your server)
+      - name: Docker Setup Compose
+        uses: docker/setup-compose-action@v1.2.0
 
-      - name: Install EverShop CLI
-        run: npm install -g evershop || true
+      # 4) Start EverShop using official docker-compose.yml
+      - name: Start EverShop with Docker
+        run: |
+          # Download official EverShop docker-compose file
+          curl -sSL https://raw.githubusercontent.com/evershopcommerce/evershop/main/docker-compose.yml > docker-compose.yml
 
-      - name: Wait for database
-        run: sleep 20
+          # Start containers (app + Postgres etc.)
+          docker compose up -d
 
-      - name: Run EverShop setup
-        run: npm run setup
+          echo "Waiting for EverShop containers to start..."
+          sleep 40
 
-      - name: Create EverShop admin user
+          echo "Running containers:"
+          docker ps
+
+      # 5) Seed data + create admin INSIDE the EverShop app container
+      - name: Seed demo data and create admin
         env:
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASS }}
         run: |
-          npm run user:create -- \
+          # Find the EverShop app container (e.g. evershop-app-1)
+          APP_CONTAINER=$(docker ps --format '{{.Names}}' | grep evershop-app | head -n 1 || true)
+
+          if [ -z "$APP_CONTAINER" ]; then
+            echo "Could not find EverShop app container"
+            docker ps
+            exit 1
+          fi
+
+          echo "Using EverShop app container: $APP_CONTAINER"
+
+          # Seed demo data so storefront has products, categories, etc.
+          echo "Seeding demo data..."
+          docker exec "$APP_CONTAINER" npm run seed -- --all || echo "Seed command not available or failed, continuing..."
+
+          # Create admin user for testRigor
+          echo "Creating admin user..."
+          docker exec "$APP_CONTAINER" npm run user:create -- \
             --email "$ADMIN_EMAIL" \
             --password "$ADMIN_PASSWORD" \
             --name "Admin"
 
-      - name: Build EverShop
-        run: npm run build
-
-      - name: Start EverShop
-        run: |
-          npm run start &
-          sleep 25
-
+      # 6) Verify storefront is really up on port 3000
       - name: Verify EverShop storefront is up
-        run: curl -LI http://localhost:3000
+        run: |
+          for i in {1..20}; do
+            if curl -sSf http://localhost:3000 > /dev/null; then
+              echo "EverShop storefront is up ✅"
+              exit 0
+            fi
+            echo "Waiting for EverShop storefront..."
+            sleep 5
+          done
+          echo "EverShop storefront did not start in time ❌"
+          exit 1
 
+      # 7) Install testRigor CLI (like you did locally)
       - name: Install testRigor CLI
         run: |
           npm install -g testrigor-cli
           testrigor --version
 
+      # 8) Run testRigor suite against the EverShop admin panel
       - name: Run testRigor suite via CLI
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -29,54 +29,8 @@ jobs:
       - name: Verify EverShop storefront is up
         run: curl -LI http://143.198.70.2:4000
 
-      - name: Run testRigor suite via API
+      - name: Run testRigor suite via CLI
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: |
-          curl -X POST \
-            -H 'Content-type: application/json' \
-            -H "auth-token: ${TESTRIGOR_CICD_TOKEN}" \
-            --data '{"forceCancelPreviousTesting":true,"storedValues":{"storedValueName1":"Value"}}' \
-            "https://api.testrigor.com/api/v1/apps/${TESTRIGOR_SUITE_ID}/retest"
-
-          sleep 10
-
-          while true
-          do
-            echo " "
-            echo "==================================="
-            echo " Checking run status"
-            echo "==================================="
-            response=$(curl -i -s -X GET "https://api.testrigor.com/api/v1/apps/${TESTRIGOR_SUITE_ID}/status" -H "auth-token: ${TESTRIGOR_CICD_TOKEN}" -H "Accept: application/json")
-            code=$(echo "$response" | grep HTTP | awk '{print $2}')
-            body=$(echo "$response" | sed -n '/{/,/}/p')
-            echo "Status code: $code"
-            echo "Response: $body"
-            case $code in
-              4*|5*)
-                echo "Error calling API"
-                exit 1
-                ;;
-              200)
-                echo "Test finished successfully"
-                exit 0
-                ;;
-              227|228)
-                echo "Test is not finished yet"
-                ;;
-              229)
-                echo "Test canceled"
-                exit 1
-                ;;
-              230)
-                echo "Test finished but failed"
-                exit 1
-                ;;
-              *)
-                echo "Unknown status"
-                exit 1
-                ;;
-            esac
-            sleep 10
-          done
+        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://143.198.70.2:4000"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -1,4 +1,4 @@
-name: EverShop + testRigor CI
+name: EverShop + testRigor CI (npm)
 
 on:
   push:
@@ -12,35 +12,87 @@ jobs:
   evershop-testrigor:
     runs-on: ubuntu-latest
 
+    # 1) Start a Postgres database for EverShop
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: evershop
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    # 2) Tell EverShop how to connect to that Postgres DB
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: evershop
+      DB_SSLMODE: disable
+
     steps:
+      # A) Get your code
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # B) Install Node.js
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "18"
 
-      - name: Install testRigor CLI
+      # C) Install npm dependencies (this installs @evershop/evershop too)
+      - name: Install dependencies
+        run: npm install
+
+      # D) Give Postgres a few seconds to be ready
+      - name: Wait for database
+        run: sleep 20
+
+      # E) Run EverShop install (creates DB tables, basic config, admin setup logic)
+      - name: Run EverShop setup
+        run: npm run setup
+
+      # F) Create EverShop admin user (this is the one you use in testRigor)
+      - name: Create EverShop admin user
+        env:
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASS }}
         run: |
-          npm install -g testrigor-cli    
-          testrigor --version
-          
-      - name: Docker Setup Compose
-        uses: docker/setup-compose-action@v1.2.0
-      
-      - name: Install Evershop with Docker
+          npm run user:create -- \
+            --email "$ADMIN_EMAIL" \
+            --password "$ADMIN_PASSWORD" \
+            --name "Admin"
+
+      # G) Build the app
+      - name: Build EverShop
+        run: npm run build
+
+      # H) Start the app (storefront + admin) in the background
+      - name: Start EverShop
         run: |
-          curl -sSL https://raw.githubusercontent.com/evershopcommerce/evershop/main/docker-compose.yml > docker-compose.yml
-          docker-compose up -d
-          npm run user:create -- --email ${{ secrets.ADMIN_EMAIL }} --password ${{ secrets.ADMIN_PASS }}  --name "Admin"
-          
+          npm run start &
+          # wait a bit for the server to start
+          sleep 25
+
+      # I) Check that the storefront is actually up
       - name: Verify EverShop storefront is up
         run: curl -LI http://localhost:3000
 
+      # J) Install testRigor CLI
+      - name: Install testRigor CLI
+        run: |
+          npm install -g testrigor-cli
+          testrigor --version
+
+      # K) Run your testRigor suite against EverShop admin
       - name: Run testRigor suite via CLI
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://localhost:3000/admin"
-
+        run: |
+          testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
+            --token "$TESTRIGOR_CICD_TOKEN" \
+            --url "http://localhost:3000/admin"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -34,7 +34,4 @@ jobs:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
         run: |
-          testrigor \
-            --cicdToken "$TESTRIGOR_CICD_TOKEN" \
-            --suiteId "$TESTRIGOR_SUITE_ID" \
-            --url "http://143.198.70.2:4000"
+          testrigor --cicdToken "$TESTRIGOR_CICD_TOKEN" --suiteId "$TESTRIGOR_SUITE_ID" --url "http://143.198.70.2:4000"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -3,11 +3,10 @@ name: EverShop + testRigor CI
 on:
   push:
     branches:
-      - main
-      - "feature/*"
+      - '**'
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
   evershop-testrigor:

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -84,7 +84,7 @@ jobs:
           echo "EverShop storefront did not start in time ❌"
           exit 1
 
-      # 7) Install testRigor CLI (like you did locally)
+      # 7) Install testRigor CLI 
       - name: Install testRigor CLI
         run: |
           npm install -g testrigor-cli
@@ -99,5 +99,7 @@ jobs:
           testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
             --token "$TESTRIGOR_CICD_TOKEN" \
             --localhost \
+            --test-cases-path packages/evershop/src/Tests/e2e-testcases/testcases/**/*.txt \
+            --rules-path packages/evershop/src/Tests/e2e-testcases/reusable-rules/**/*.txt \
             --url "http://localhost:3000/admin"
 

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -37,12 +37,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: '18'
 
       - name: Install dependencies
         run: npm install
 
-      # 🔥 FIX: Add EverShop CLI installation
       - name: Install EverShop CLI
         run: |
           npm install -g @evershop/cli
@@ -81,3 +80,10 @@ jobs:
           testrigor --version
 
       - name: Run testRigor suite via CLI
+        env:
+          TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
+          TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
+        run: |
+          testrigor test-suite run "$TESTRIGOR_SUITE_ID" \
+            --token "$TESTRIGOR_CICD_TOKEN" \
+            --url "http://localhost:3000/admin"

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install EverShop CLI
         run: |
-          npm install -g @evershop/cli
+          npm install -g evershop
           evershop --version
 
       - name: Wait for database

--- a/.github/workflows/evershop-testrigor.yml
+++ b/.github/workflows/evershop-testrigor.yml
@@ -33,4 +33,5 @@ jobs:
         env:
           TESTRIGOR_CICD_TOKEN: ${{ secrets.TESTRIGOR_CICD_TOKEN }}
           TESTRIGOR_SUITE_ID: ${{ vars.TESTRIGOR_SUITE_ID }}
-        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://143.198.70.2:4000"
+        run: testrigor test-suite run "$TESTRIGOR_SUITE_ID" --token "$TESTRIGOR_CICD_TOKEN" --url "http://143.198.70.2:4000/admin"
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Trigger CI run2 -->
+<!-- Trigger CI run -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Trigger CI run -->
+<!-- Trigger CI run 1 -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Trigger CI run 2 -->
+<!-- Trigger CI run -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- Trigger CI run -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Trigger CI run -->
+<!-- Trigger CI run 2 -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Trigger CI run -->
+<!-- Trigger CI run2 -->
 <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
 <p align="center">
 <img width="60" height="68" alt="EverShop Logo" src="https://raw.githubusercontent.com/evershopcommerce/evershop/dev/.github/images/logo-green.png"/>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

EverShop currently does not run testRigor-based end-to-end tests in CI. There is no automated E2E coverage via testRigor wired into repository workflows.

Issue Number: N/A


## What is the new behavior?

This PR adds testRigor end-to-end testing integration:
- EverShop is started in CI using the official Docker Compose setup.
- Demo data is seeded and an admin user is created in CI.
- testRigor CLI triggers the EverShop suite on testRigor and runs against `http://localhost:3000/admin`.
- Test cases and reusable rules are loaded directly from this repo.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

### Changes proposed in this Pull Request:
This pull request adds end-to-end test cases using testRigor for EverShop.

testRigor is an AI-powered end-to-end testing platform that allows you to write tests in plain English. This setup enables automated testing of EverShop’s UI and functionality from a user’s perspective, covering Admin and Storefront flows.

What’s included:
- 1 new workflow file that performs a full run of this [test suite](https://app.testrigor.com/test-suites/oJvBxgjY5A8Pw48hj/test-cases) when triggered.
- 1 new folder at `packages/evershop/src/Tests/e2e-testcases/` containing:
  - `testcases/` (plain-English tests)
  - `reusable-rules/` (shared rules)
  - `README.md`

Latest successful CI run:
https://github.com/Divyoth1234/evershop/actions/runs/19906929870

### Why testRigor?
- Test cases written in plain English: anyone can contribute automated tests without coding, enabling broader coverage.
- Reduced maintenance overhead: tests are resilient to UI changes.
- Cross-platform coverage: works across desktop, mobile, and web.

### How to test the changes in this Pull Request:

#### CI (automatic)
- Any push or pull request triggers `.github/workflows/evershop-testrigor.yml`.
- The workflow starts EverShop via Docker Compose, seeds demo data, creates an admin user, then runs the testRigor suite against `http://localhost:3000/admin`.

#### Local (manual)

    1. Start EverShop locally:
       ```bash
       curl -sSL https://raw.githubusercontent.com/evershopcommerce/evershop/main/docker-compose.yml > docker-compose.yml
       docker compose up -d
    
    2.Seed demo data and create an admin user:
        APP_CONTAINER=$(docker ps --format '{{.Names}}' | grep evershop-app | head -n 1)
    
        docker exec "$APP_CONTAINER" npm run seed -- --all
        docker exec "$APP_CONTAINER" npm run user:create -- \
          --email "<ADMIN_EMAIL>" \
          --password "<ADMIN_PASSWORD>" \
          --name "Admin"
    
    3. Install testRigor CLI:
        npm install -g testrigor-cli
    
    4. Run the suite:
    
        testrigor test-suite run <SUITE_ID> \
          --token <CI_TOKEN> \
          --localhost \
          --test-cases-path packages/evershop/src/Tests/e2e-testcases/testcases/**/*.txt \
          --rules-path packages/evershop/src/Tests/e2e-testcases/reusable-rules/**/*.txt \
          --url "http://localhost:3000/admin"
      
Replace the items between "< >" with the corresponding values:

 - SUITE_ID: the ID of the test suite itself, it's located in the URL (i.e. for the following test suite: https://app.testrigor.com/test-suites/oJvBxgjY5A8Pw48hj/test-cases , the SUITE_ID is: oJvBxgjY5A8Pw48hj

- CI_TOKEN: To get the CI token follow these steps:
   - Open the test suite that has been previously set up.
    - Click "CI/CD Integration" located on the sidebar.
    - The auth token should be located there (refer to the image posted below).
    - Copy the CI token then use it on the CLI command.
    
<img width="779" height="271" alt="Screenshot 2025-12-04 at 4 29 04 PM" src="https://github.com/user-attachments/assets/ae973e42-3758-4f80-bab9-d9198e78c9de" />

    


