### PR TITLE
Fix: increase default limit in CategorySelector from 10 to 50

### DIFF
--- a/packages/evershop/src/components/admin/CategorySelector.tsx
+++ b/packages/evershop/src/components/admin/CategorySelector.tsx
@@ -70,7 +70,8 @@ const CategorySelector: React.FC<{
   const [internalSelectedCategories, setInternalSelectedCategories] =
     React.useState<AtLeastOne<CategoryIdentifier>[]>(selectedCategories || []);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const limit = 10;
+  const DEFAULT_SELECTOR_LIMIT = 50;
+const limit = DEFAULT_SELECTOR_LIMIT;
   const [inputValue, setInputValue] = React.useState<string>('');
   const [page, setPage] = React.useState(1);
 


### PR DESCRIPTION
Fix: Increase default category selector limit

The CategorySelector component used a default limit = 10, restricting the number of categories visible per page in product registration.

This change increases the default limit to 50 while preserving pagination behavior.

Tested with 80 child categories.