### PR TITLE
fix: make customer login and register pages responsive

### DIFF
--- a/packages/evershop/src/modules/customer/pages/frontStore/login/LoginPage.tsx
+++ b/packages/evershop/src/modules/customer/pages/frontStore/login/LoginPage.tsx
@@ -17,8 +17,8 @@ export default function LoginPage({
 }: LoginPageProps) {
   return (
     <div className="login__page flex flex-col justify-center items-center">
-      <Card className="flex justify-center items-center max-w-max md:max-w-[80%]">
-        <CardContent>
+      <Card className="flex justify-center items-center w-full max-w-md md:max-w-[80%]">
+        <CardContent className="w-full">
           <CustomerLoginForm
             title={_('Welcome Back!')}
             subtitle={_('Please sign in to your account')}
@@ -26,7 +26,7 @@ export default function LoginPage({
             onError={(error) => {
               toast.error(error.message);
             }}
-            className="w-120"
+            className="w-full"
           />
         </CardContent>
       </Card>

--- a/packages/evershop/src/modules/customer/pages/frontStore/register/RegisterPage.tsx
+++ b/packages/evershop/src/modules/customer/pages/frontStore/register/RegisterPage.tsx
@@ -11,8 +11,8 @@ interface RegisterPageProps {
 export default function RegisterPage({ homeUrl, loginUrl }: RegisterPageProps) {
   return (
     <div className="flex justify-center items-center flex-col gap-3">
-      <Card className="flex justify-center items-center max-w-max md:max-w-[80%]">
-        <CardContent>
+      <Card className="flex justify-center items-center w-full max-w-md md:max-w-[80%]">
+        <CardContent className="w-full">
           <CustomerRegistrationForm
             title={_('Create an account')}
             subtitle={_('Join us for exclusive offers and order tracking')}
@@ -20,7 +20,7 @@ export default function RegisterPage({ homeUrl, loginUrl }: RegisterPageProps) {
             onError={(error) => {
               toast.error(error);
             }}
-            className="w-120"
+            className="w-full"
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Issue:
The customer login and registration forms had a fixed width class (w-120) that caused a horizontal overflow on mobile devices (screens smaller than 480px). This resulted in a poor user experience where the form would bleed out of the viewport.

## Solution:
I replaced the fixed width with responsive Tailwind classes to ensure the forms adapt to smaller screens while maintaining a clean look on desktop.

## Changes:
* LoginPage.tsx: Changed w-120 to w-full max-w-md on the CustomerLoginForm component. Also updated the wrapping Card and CardContent to use w-full for proper fluid scaling.
* RegisterPage.tsx: Applied the same fix to the CustomerRegistrationForm, ensuring the registration process is now fully responsive.
 
## Technical details:
Replaced max-w-max with w-full max-w-md to allow the container to shrink on mobile.
Used w-full on inner components to inherit the container's width.
Maintained the original md:max-w-[80%] constraint for larger screens to preserve the intended desktop design.

## Files modified:
packages/evershop/src/modules/customer/pages/frontStore/login/LoginPage.tsx
packages/evershop/src/modules/customer/pages/frontStore/register/RegisterPage.tsx
