### PR TITLE
Fix #630: Product registration does not list all child categories

### DIFF
--- a/packages/evershop/src/components/admin/CategoryTree.tsx
+++ b/packages/evershop/src/components/admin/CategoryTree.tsx
@@ -127,7 +127,7 @@ function CategoryItem({
           <ul>
             {data.categories.items.map((child) => (
               <CategoryItem
-                key={child.value}
+                key={child.categoryId}
                 category={child}
                 selectedCategories={selectedCategories}
                 onSelect={onSelect}
@@ -178,7 +178,7 @@ function CategoryTree({ selectedCategories, onSelect }: CategoryTreeProps) {
     <ul className="category-tree">
       {data.categories.items.map((category) => (
         <CategoryItem
-          key={category.value}
+          key={category.categoryId}
           category={category}
           selectedCategories={selectedCategories}
           onSelect={onSelect}

--- a/packages/evershop/src/modules/catalog/services/CategoryCollection.js
+++ b/packages/evershop/src/modules/catalog/services/CategoryCollection.js
@@ -13,6 +13,17 @@ export class CategoryCollection {
       this.baseQuery.andWhere('category.status', '=', 1);
     }
     const currentFilters = [];
+    const hasParentFilter = filters.some(
+      (filter) => filter.key === 'parent' && filter.operation === 'eq'
+    );
+    const hasPageFilter = filters.some(
+      (filter) => filter.key === 'page' && filter.operation === 'eq'
+    );
+    const hasLimitFilter = filters.some(
+      (filter) => filter.key === 'limit' && filter.operation === 'eq'
+    );
+    const skipDefaultPagination =
+      hasParentFilter && !hasPageFilter && !hasLimitFilter;
 
     // Apply the filters
     const categoryCollectionFilters = await getValue(
@@ -27,6 +38,9 @@ export class CategoryCollection {
       const check = filters.find(
         (f) => f.key === filter.key && filter.operation.includes(f.operation)
       );
+      if (filter.key === '*' && skipDefaultPagination) {
+        return;
+      }
       if (filter.key === '*' || check) {
         filter.callback(
           this.baseQuery,

--- a/packages/evershop/src/modules/catalog/tests/intergration/categoryCollectionPagination.test.js
+++ b/packages/evershop/src/modules/catalog/tests/intergration/categoryCollectionPagination.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const getValueMock = jest.fn();
+
+jest.unstable_mockModule('../../../../lib/util/registry.js', () => ({
+  getValue: getValueMock
+}));
+
+jest.unstable_mockModule('../../../../lib/postgres/connection.js', () => ({
+  pool: {}
+}));
+
+const { CategoryCollection } = await import('../../services/CategoryCollection.js');
+
+class MockQuery {
+  constructor() {
+    this.limitCalls = [];
+    this.orderByCalls = [];
+    this.andWhereCalls = [];
+    this.selectCalls = [];
+    this.removeOrderByCalls = 0;
+    this.removeLimitCalls = 0;
+  }
+
+  orderBy(field, direction) {
+    this.orderByCalls.push({ field, direction });
+    return this;
+  }
+
+  andWhere(field, operator, value) {
+    this.andWhereCalls.push({ field, operator, value });
+    return this;
+  }
+
+  limit(offset, limit) {
+    this.limitCalls.push({ offset, limit });
+    return this;
+  }
+
+  clone() {
+    return this;
+  }
+
+  select(field, alias) {
+    this.selectCalls.push({ field, alias });
+    return this;
+  }
+
+  removeOrderBy() {
+    this.removeOrderByCalls += 1;
+    return this;
+  }
+
+  removeLimit() {
+    this.removeLimitCalls += 1;
+    return this;
+  }
+}
+
+const buildFilterSet = () => [
+  {
+    key: 'parent',
+    operation: ['eq'],
+    callback: (query, operation, value, currentFilters) => {
+      currentFilters.push({ key: 'parent', operation, value });
+    }
+  },
+  {
+    key: 'page',
+    operation: ['eq'],
+    callback: (query, operation, value, currentFilters) => {
+      query.limit((parseInt(value, 10) - 1) * 20, 20);
+      currentFilters.push({ key: 'page', operation, value });
+    }
+  },
+  {
+    key: 'limit',
+    operation: ['eq'],
+    callback: (query, operation, value, currentFilters) => {
+      query.limit(0, parseInt(value, 10));
+      currentFilters.push({ key: 'limit', operation, value });
+    }
+  },
+  {
+    key: '*',
+    operation: ['eq'],
+    callback: (query, operation, value, currentFilters) => {
+      const limitFilter = currentFilters.find((f) => f.key === 'limit');
+      const limit = parseInt(limitFilter?.value || 20, 10);
+      currentFilters.push({ key: 'page', operation: 'eq', value: 1 });
+      currentFilters.push({ key: 'limit', operation: 'eq', value: limit });
+      query.limit(0, limit);
+    }
+  }
+];
+
+describe('CategoryCollection pagination with parent filter', () => {
+  beforeEach(() => {
+    getValueMock.mockReset();
+    getValueMock.mockResolvedValue(buildFilterSet());
+  });
+
+  it('skips implicit pagination for parent filter when page/limit are absent', async () => {
+    const query = new MockQuery();
+    const collection = new CategoryCollection(query);
+
+    await collection.init([{ key: 'parent', operation: 'eq', value: 8 }], true);
+
+    expect(query.limitCalls).toEqual([]);
+  });
+
+  it('keeps explicit pagination with parent filter', async () => {
+    const query = new MockQuery();
+    const collection = new CategoryCollection(query);
+
+    await collection.init(
+      [
+        { key: 'parent', operation: 'eq', value: 8 },
+        { key: 'limit', operation: 'eq', value: 10 }
+      ],
+      true
+    );
+
+    expect(query.limitCalls).toEqual([
+      { offset: 0, limit: 10 },
+      { offset: 0, limit: 10 }
+    ]);
+  });
+
+  it('keeps default pagination for non-parent queries', async () => {
+    const query = new MockQuery();
+    const collection = new CategoryCollection(query);
+
+    await collection.init([], true);
+
+    expect(query.limitCalls).toEqual([{ offset: 0, limit: 20 }]);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When selecting a category in product registration (or when choosing a parent category in category edit), the admin category tree only shows a limited number of child categories per parent (capped by default collection size, e.g. 20). Parents with many children (e.g. 75) appear truncated: not all children are listed or selectable.

Issue Number: #630


## What is the new behavior?

 - Backend: For categories GraphQL queries that use only a parent filter (and no explicit page/limit), default pagination is no longer applied. All children for that parent are returned, so the tree can show the full list (e.g. all 75 children).
 - Frontend: Category tree list items use stable React keys (categoryId instead of value) so rendering is consistent when many children are shown.
 - Tests: New integration test categoryCollectionPagination.test.js asserts that parent-only category queries are not paginated, and that explicit page/limit still apply when provided.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Fixes #630.
Manual check: expand a parent with many children in Admin → Products → New Product → Category, and in Admin → Category → Edit → Parent category; all children should appear.
