### PR TITLE
fix: convert backslash paths to forward slashes for Tailwind v4 on Windows

### DIFF
--- a/packages/evershop/src/lib/webpack/util/getTailwindSources.ts
+++ b/packages/evershop/src/lib/webpack/util/getTailwindSources.ts
@@ -23,5 +23,5 @@ export function getTailwindSources(): string[] {
     sources.push(path.resolve(theme.path, '**/*.{js,jsx,ts,tsx}'));
   }
 
-  return sources;
+  return sources.map((s) => s.replace(/\\/g, '/'));
 }


### PR DESCRIPTION
## Summary
On Windows, Tailwind v4 @source directives break because `path.resolve` uses backslashes, resulting in missing utility classes (like `rounded-xl`, `shadow-xs`, `ring-1`) from the compiled CSS.

This commit converts the backslashes to forward slashes.

## Problem
Closes #890

## Solution
Wrapped the returned sources in `getTailwindSources` with `sources.map((s) => s.replace(/\\\\/g, '/'))` ensuring that Tailwind can correctly parse and apply the paths.

## Testing
- [x] Code builds without errors
- [x] Tested the local configuration change
