### PR TITLE
feat: add noscript support to headTags

### DIFF
--- a/packages/evershop/src/lib/util/getConfig.ts
+++ b/packages/evershop/src/lib/util/getConfig.ts
@@ -92,6 +92,7 @@ type ConfigStructure = {
       metas: any[];
       scripts: any[];
       bases: any[];
+      noscripts: any[];
     };
     copyRight: string;
   };

--- a/packages/evershop/src/modules/base/pages/frontStore/all/HeadTags.tsx
+++ b/packages/evershop/src/modules/base/pages/frontStore/all/HeadTags.tsx
@@ -35,13 +35,14 @@ interface HeadTagsProps {
         href: string;
         target: '_blank' | '_self' | '_parent' | '_top';
       };
+      noscripts?: Array<{ html: string }>;
     };
   };
 }
 export default function HeadTags({
   pageInfo: { title, description, keywords, canonicalUrl, ogInfo, favicon },
   themeConfig: {
-    headTags: { metas, links, scripts, base }
+    headTags: { metas, links, scripts, base, noscripts }
   }
 }: HeadTagsProps) {
   React.useEffect(() => {
@@ -77,6 +78,13 @@ export default function HeadTags({
       )}
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       {base && <base {...base} />}
+      {noscripts &&
+        noscripts.map((noscript, index) => (
+          <noscript
+            key={index}
+            dangerouslySetInnerHTML={{ __html: noscript.html }}
+          />
+        ))}
       <Og
         type={ogInfo.type}
         title={title}
@@ -160,6 +168,9 @@ export const query = `
         base {
           href
           target
+        }
+        noscripts {
+          html
         }
       }
     }

--- a/packages/evershop/src/modules/cms/bootstrap.ts
+++ b/packages/evershop/src/modules/cms/bootstrap.ts
@@ -115,6 +115,18 @@ export default () => {
                     },
                     required: ['href']
                   }
+                },
+                noscripts: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      html: {
+                        type: 'string'
+                      }
+                    },
+                    required: ['html']
+                  }
                 }
               }
             }
@@ -145,7 +157,8 @@ export default () => {
       links: [],
       metas: [],
       scripts: [],
-      bases: []
+      bases: [],
+      noscripts: []
     },
     copyRight: `© 2022 Evershop. All Rights Reserved.`
   };

--- a/packages/evershop/src/modules/cms/graphql/types/ThemeConfig/ThemeConfig.graphql
+++ b/packages/evershop/src/modules/cms/graphql/types/ThemeConfig/ThemeConfig.graphql
@@ -67,11 +67,22 @@ type Logo {
 """
 Represents a nav head tag.
 """
+"""
+Represents a noscript html tag.
+"""
+type Noscript {
+  html: String
+}
+
+"""
+Represents a nav head tag.
+"""
 type HeadTag {
   links: [Link]
   metas: [Meta]
   scripts: [Script]
   base: Base
+  noscripts: [Noscript]
 }
 
 """


### PR DESCRIPTION
Closes #663. Added noscript option in themeConfig headTags to support elements like Facebook Pixel.