### PR TITLE
fix: CategoryTree not showing all child categories

### DIFF
--- a/packages/evershop/src/components/admin/CategoryTree.tsx
+++ b/packages/evershop/src/components/admin/CategoryTree.tsx
@@ -38,6 +38,7 @@ const childrenQuery = `
         }
         hasChildren
       }
+      total
     }
   }
 `;
@@ -67,7 +68,10 @@ function CategoryItem({
   const [result] = useQuery({
     query: childrenQuery,
     variables: {
-      filters: [{ key: 'parent', operation: 'eq', value: category.categoryId }]
+      filters: [
+        { key: 'parent', operation: 'eq', value: category.categoryId },
+        { key: 'limit', operation: 'eq', value: '1000' }
+      ]
     },
     pause: !expanded
   });
@@ -127,7 +131,7 @@ function CategoryItem({
           <ul>
             {data.categories.items.map((child) => (
               <CategoryItem
-                key={child.value}
+                key={child.categoryId}
                 category={child}
                 selectedCategories={selectedCategories}
                 onSelect={onSelect}
@@ -159,7 +163,10 @@ function CategoryTree({ selectedCategories, onSelect }: CategoryTreeProps) {
   const [result] = useQuery({
     query: categoriesQuery,
     variables: {
-      filters: [{ key: 'parent', operation: 'eq', value: null }]
+      filters: [
+        { key: 'parent', operation: 'eq', value: null },
+        { key: 'limit', operation: 'eq', value: '1000' }
+      ]
     }
   });
   const { data, fetching, error } = result;
@@ -178,7 +185,7 @@ function CategoryTree({ selectedCategories, onSelect }: CategoryTreeProps) {
     <ul className="category-tree">
       {data.categories.items.map((category) => (
         <CategoryItem
-          key={category.value}
+          key={category.categoryId}
           category={category}
           selectedCategories={selectedCategories}
           onSelect={onSelect}


### PR DESCRIPTION
Fixes #630

## Problem
The CategoryTree component was not displaying all child categories when a parent category had more than 20 children (default pagination limit). This was reported in issue #630 where a category with 75 child rows in the database only showed a subset in the UI.

## Root Cause
The GraphQL queries in CategoryTree.tsx did not specify pagination parameters, causing the API to apply default pagination (20 items per page). This meant only 20 child categories were fetched regardless of the actual number of children.

## Changes
1. Added limit filter to both root categories query and children queries to fetch up to 1000 categories
2. Fixed React key prop warnings by changing key={child.value} to key={child.categoryId}
3. Added total field to childrenQuery for potential future pagination UI improvements

## Testing
- Categories with 75+ children now display correctly
- No more React key warnings in console
- Backward compatible