### PR TITLE
Fix: render sub-items on mobile menu via accordion toggle

### DIFF
--- a/packages/evershop/src/modules/cms/components/BasicMenu.tsx
+++ b/packages/evershop/src/modules/cms/components/BasicMenu.tsx
@@ -10,24 +10,101 @@ import {
 import { cn } from '@evershop/evershop/lib/util/cn';
 import React from 'react';
 
+interface MenuItem {
+  id: string;
+  name: string;
+  url: string;
+  type: string;
+  uuid: string;
+  children: {
+    name: string;
+    url: string;
+    type: string;
+    uuid: string;
+  }[];
+}
+
 interface BasicMenuProps {
   basicMenuWidget: {
-    menus: {
-      id: string;
-      name: string;
-      url: string;
-      type: string;
-      uuid: string;
-      children: {
-        name: string;
-        url: string;
-        type: string;
-        uuid: string;
-      }[];
-    }[];
+    menus: MenuItem[];
     isMain: boolean;
     className: string;
   };
+}
+
+/**
+ * Accordion item for mobile: the parent name links to the category page
+ * while a chevron toggle expands/collapses the list of child links.
+ */
+function MobileAccordionItem({
+  item,
+  isActive
+}: {
+  item: MenuItem;
+  isActive: (url: string) => boolean;
+}) {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <li className="w-full">
+      <div className="flex items-center justify-between w-full">
+        <a
+          href={item.url}
+          className={cn(
+            'flex-1 px-4 py-2 text-xl transition-colors hover:underline hover:text-primary',
+            isActive(item.url) ? 'text-primary font-semibold' : ''
+          )}
+        >
+          {item.name}
+        </a>
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} ${item.name}`}
+          className="p-2 mr-2 cursor-pointer text-gray-500 hover:text-primary transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className={cn(
+              'w-5 h-5 transition-transform duration-200',
+              expanded ? 'rotate-180' : ''
+            )}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      {expanded && (
+        <ul className="pl-6 pb-1">
+          {item.children.map((child) => (
+            <li key={child.uuid}>
+              <a
+                href={child.url}
+                className={cn(
+                  'block px-4 py-1.5 text-base transition-colors hover:underline hover:text-primary',
+                  isActive(child.url)
+                    ? 'text-primary font-semibold'
+                    : 'text-gray-600'
+                )}
+              >
+                {child.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
 }
 
 export default function BasicMenu({
@@ -93,46 +170,70 @@ export default function BasicMenu({
                 'md:flex'
               )}
             >
-              <NavigationMenu className="w-full max-w-full">
-                <NavigationMenuList className="flex-col md:flex-row items-start md:items-center w-full md:w-auto">
-                  {menus.map((item) => (
-                    <NavigationMenuItem
-                      key={item.uuid}
-                      className="w-full md:w-auto"
-                    >
-                      {item.children.length > 0 && !isMobile ? (
-                        <>
-                          <NavigationMenuTrigger className="w-full md:w-auto justify-start md:justify-center bg-transparent hover:bg-transparent focus:bg-transparent data-open:bg-transparent data-open:hover:bg-transparent data-open:focus:bg-transparent data-popup-open:bg-transparent data-popup-open:hover:bg-transparent hover:font-semibold hover:text-primary">
-                            {item.name}
-                          </NavigationMenuTrigger>
-                          <NavigationMenuContent>
-                            <ul className="flex flex-col min-w-50 p-2">
-                              {item.children.map((subItem) => (
-                                <li key={subItem.uuid}>
-                                  <NavigationMenuLink
-                                    href={subItem.url}
-                                    className="w-full"
-                                  >
-                                    {subItem.name}
-                                  </NavigationMenuLink>
-                                </li>
-                              ))}
-                            </ul>
-                          </NavigationMenuContent>
-                        </>
-                      ) : (
+              {isMobile ? (
+                <ul className="flex flex-col w-full">
+                  {menus.map((item) =>
+                    item.children.length > 0 ? (
+                      <MobileAccordionItem
+                        key={item.uuid}
+                        item={item}
+                        isActive={isActive}
+                      />
+                    ) : (
+                      <li key={item.uuid} className="w-full">
                         <NavigationMenuLink
                           href={item.url}
-                          className="w-full md:w-auto px-4 py-2 hover:text-primary data-[active=true]:bg-transparent data-[active=true]:hover:bg-transparent transition-colors data-[active=true]:text-primary data-[active=true]:font-semibold hover:bg-transparent focus:bg-transparent hover:underline text-xl md:text-base"
+                          className="w-full px-4 py-2 hover:text-primary data-[active=true]:bg-transparent data-[active=true]:hover:bg-transparent transition-colors data-[active=true]:text-primary data-[active=true]:font-semibold hover:bg-transparent focus:bg-transparent hover:underline text-xl"
                           data-active={isActive(item.url)}
                         >
                           {item.name}
                         </NavigationMenuLink>
-                      )}
-                    </NavigationMenuItem>
-                  ))}
-                </NavigationMenuList>
-              </NavigationMenu>
+                      </li>
+                    )
+                  )}
+                </ul>
+              ) : (
+                <NavigationMenu className="w-full max-w-full">
+                  <NavigationMenuList className="flex-col md:flex-row items-start md:items-center w-full md:w-auto">
+                    {menus.map((item) => (
+                      <NavigationMenuItem
+                        key={item.uuid}
+                        className="w-full md:w-auto"
+                      >
+                        {item.children.length > 0 ? (
+                          <>
+                            <NavigationMenuTrigger className="w-full md:w-auto justify-start md:justify-center bg-transparent hover:bg-transparent focus:bg-transparent data-open:bg-transparent data-open:hover:bg-transparent data-open:focus:bg-transparent data-popup-open:bg-transparent data-popup-open:hover:bg-transparent hover:font-semibold hover:text-primary">
+                              {item.name}
+                            </NavigationMenuTrigger>
+                            <NavigationMenuContent>
+                              <ul className="flex flex-col min-w-50 p-2">
+                                {item.children.map((subItem) => (
+                                  <li key={subItem.uuid}>
+                                    <NavigationMenuLink
+                                      href={subItem.url}
+                                      className="w-full"
+                                    >
+                                      {subItem.name}
+                                    </NavigationMenuLink>
+                                  </li>
+                                ))}
+                              </ul>
+                            </NavigationMenuContent>
+                          </>
+                        ) : (
+                          <NavigationMenuLink
+                            href={item.url}
+                            className="w-full md:w-auto px-4 py-2 hover:text-primary data-[active=true]:bg-transparent data-[active=true]:hover:bg-transparent transition-colors data-[active=true]:text-primary data-[active=true]:font-semibold hover:bg-transparent focus:bg-transparent hover:underline text-xl md:text-base"
+                            data-active={isActive(item.url)}
+                          >
+                            {item.name}
+                          </NavigationMenuLink>
+                        )}
+                      </NavigationMenuItem>
+                    ))}
+                  </NavigationMenuList>
+                </NavigationMenu>
+              )}
             </div>
           </div>
         </nav>


### PR DESCRIPTION
## Problem

The `BasicMenu` widget renders menu items that have children as **plain links on mobile**, making child pages completely inaccessible. For example, if "DrinkWare" has sub-items "Mugs" and "Tumblers", tapping "DrinkWare" on mobile navigates directly to the category page with no way to reach the children.

The root cause is the condition on [line 103](https://github.com/evershopcommerce/evershop/blob/dev/packages/evershop/src/modules/cms/components/BasicMenu.tsx#L103):

```tsx
{item.children.length > 0 && !isMobile ? (
  // Desktop: NavigationMenuTrigger + NavigationMenuContent (dropdown)
) : (
  // Mobile OR no children: plain NavigationMenuLink — children are silently dropped
)}
```

On mobile (`isMobile === true`), the `!isMobile` check causes items with children to fall through to the else branch, which renders only the parent as a link and **never renders the children**.

Desktop:

<img width="420" height="195" alt="image" src="https://github.com/user-attachments/assets/18b9a6fb-a0e5-4c99-b29d-b6d4d19484c1" />

Mobile(no sub menus):

<img width="369" height="234" alt="image" src="https://github.com/user-attachments/assets/893aa29e-efec-4315-b25f-601cca0be080" />



## Solution

Split the render into two explicit branches — mobile and desktop:

- **Desktop** (unchanged): `NavigationMenuTrigger` + `NavigationMenuContent` dropdown
- **Mobile** (new): An accordion pattern via a `MobileAccordionItem` component that:
  - Shows the parent name as a **navigable link** to the category page
  - Adds a **chevron toggle button** that expands/collapses child links below
  - Includes `aria-expanded` and `aria-label` for accessibility
  - Uses a 200ms rotate transition on the chevron indicator

New Mobile view:

<img width="385" height="315" alt="image" src="https://github.com/user-attachments/assets/4bdee0cb-8f54-4c7a-b11b-adf59a283b00" />


## Changes

Single file: `packages/evershop/src/modules/cms/components/BasicMenu.tsx`

- Extract `MenuItem` interface to top level (was inline, needed by both components)
- Add `MobileAccordionItem` component (~50 lines)
- Replace the single ternary with a `isMobile ? <accordion list> : <NavigationMenu dropdown>` branch
- No new dependencies

## Testing

- Lint passes with 0 errors (`npm run lint`)
- Desktop menu behavior is identical (no changes to the NavigationMenu branch)
- On mobile (< 768px): items without children render as plain links; items with children show parent link + chevron toggle that expands children